### PR TITLE
Add run options with default config path

### DIFF
--- a/docs/en/development/build-osx.md
+++ b/docs/en/development/build-osx.md
@@ -124,4 +124,10 @@ Reboot.
 
 To check if it’s working, you can use `ulimit -n` command.
 
+## Run ClickHouse server:
+
+```
+~/ClickHouse/build/programs/clickhouse-server --config-file ~/ClickHouse/programs/server/config.xml
+```
+
 [Original article](https://clickhouse.tech/docs/en/development/build_osx/) <!--hide-->


### PR DESCRIPTION
Add run options with default config path according to https://github.com/ClickHouse/ClickHouse/issues/23875.
Checked on Catalina 10.15.7

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Changelog category (leave one):
- New Feature
- Bug Fix
- Improvement
- Performance Improvement
- Backward Incompatible Change
- Build/Testing/Packaging Improvement
- Documentation (changelog entry is not required)
- Other
- Not for changelog (changelog entry is not required)


Changelog entry (a user-readable short description of the changes that goes to CHANGELOG.md):

...


Detailed description / Documentation draft:

...

By adding documentation, you'll allow users to try your new feature immediately, not when someone else will have time to document it later. Documentation is necessary for all features that affect user experience in any way. You can add brief documentation draft above, or add documentation right into your patch as Markdown files in [docs](https://github.com/ClickHouse/ClickHouse/tree/master/docs) folder.

If you are doing this for the first time, it's recommended to read the lightweight [Contributing to ClickHouse Documentation](https://github.com/ClickHouse/ClickHouse/tree/master/docs/README.md) guide first.


Information about CI checks: https://clickhouse.tech/docs/en/development/continuous-integration/
